### PR TITLE
Fix RuntimeError trying to set custom Java location when none is found.

### DIFF
--- a/leiningen-installer.iss
+++ b/leiningen-installer.iss
@@ -353,9 +353,9 @@ begin
     end
     else
     begin
-      SelectedJdkIndex := JdkIndexes[JdkPage.SelectedValueIndex];
       if JdkPage.SelectedValueIndex <> CustomJdkIndex then
       begin
+        SelectedJdkIndex := JdkIndexes[JdkPage.SelectedValueIndex];
         SetSelectedJdkLocation();
       end
     end


### PR DESCRIPTION
When the installer cannot find any Java installation, selecting the "Custom location&hellip;" option and pressing Next causes an error to be displayed ("Runtime Error (at 28:617): Out Of Range") and prevents the setup from continuing.

This is caused by the following line:

``` pas
SelectedJdkIndex := JdkIndexes[JdkPage.SelectedValueIndex];
```

which breaks because in this case `JdkIndexes` is an empty array. Moving the line inside the `if JdkPage.SelectedValueIndex <> CustomJdkIndex` block fixes this.

This fixes the second point mentioned in https://github.com/djpowell/leiningen-win-installer/issues/2#issuecomment-86881797.
